### PR TITLE
Fix center alignment of empty results

### DIFF
--- a/pages/followers.html
+++ b/pages/followers.html
@@ -51,6 +51,7 @@
       };
 
       if (followersOnlyList.length === 0) {
+        listContainer.classList.add('no-results');
         const card = document.createElement('div');
         card.className = 'card';
         card.textContent = 'No followers only connections found.';

--- a/pages/following.html
+++ b/pages/following.html
@@ -51,6 +51,7 @@
       };
 
       if (followingOnlyList.length === 0) {
+        listContainer.classList.add('no-results');
         const card = document.createElement('div');
         card.className = 'card';
         card.textContent = 'No following only connections found.';

--- a/pages/mutual.html
+++ b/pages/mutual.html
@@ -51,6 +51,7 @@
       };
 
       if (mutualList.length === 0) {
+        listContainer.classList.add('no-results');
         const card = document.createElement('div');
         card.className = 'card';
         card.textContent = 'No mutual connections found.';

--- a/styles.css
+++ b/styles.css
@@ -231,7 +231,17 @@ p {
     margin: 0 auto;
     direction: ltr;  /* Items ordered right-to–left per row */
     padding-bottom: 20px;  /* Padding beneath the cards */
-  }
+}
+
+/* Layout adjustments when no results are present */
+.list-container.no-results {
+    display: flex;
+    justify-content: center;
+}
+
+.list-container.no-results .card {
+    text-align: center;
+}
   
   /* Card design for each list item */
   .card {


### PR DESCRIPTION
## Summary
- add a `.no-results` layout so empty results are centered
- mark empty results containers with the new class on all results pages

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846609c07948320ac2c4cbddb512201