### PR TITLE
Add confirmation dialog before clearing stored runs

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,15 @@
         <button type="submit" class="btn">Add Run</button>
         <span id="update-file-name" class="file-name">No file chosen</span>
       </form>
+      <div id="confirm-overlay" class="modal-overlay" style="display:none;">
+        <div class="modal">
+          <p class="warning-text">Warning, this cannot be undone.</p>
+          <label class="ack-label">
+            <input type="checkbox" id="ack-checkbox"> I understand
+          </label>
+          <button id="confirm-clear-btn" class="btn" style="display:none;">Confirm</button>
+        </div>
+      </div>
       </div>
     </main>
   <footer>

--- a/script.js
+++ b/script.js
@@ -7,6 +7,9 @@ document.addEventListener('DOMContentLoaded', function() {
   const updateForm = document.getElementById('update-form');
   const resultsDiv = document.getElementById('results');
   const clearBtn = document.getElementById('clear-btn');
+  const confirmOverlay = document.getElementById('confirm-overlay');
+  const ackCheckbox = document.getElementById('ack-checkbox');
+  const confirmClearBtn = document.getElementById('confirm-clear-btn');
 
   // Bail out if elements aren't present (e.g., help page)
   if (!fileInput || !uploadForm || !resultsDiv) {
@@ -241,22 +244,47 @@ document.addEventListener('DOMContentLoaded', function() {
     });
   }
 
+  const clearData = () => {
+    localStorage.removeItem('mutualList');
+    localStorage.removeItem('followingOnlyList');
+    localStorage.removeItem('followersOnlyList');
+    localStorage.removeItem('hasResults');
+    localStorage.removeItem('dataRuns');
+    resultsDiv.innerHTML = '';
+    resultsDiv.style.display = 'none';
+    clearBtn.style.display = 'none';
+    uploadForm.style.display = 'flex';
+    if (updateForm) updateForm.style.display = 'none';
+    fileInput.value = '';
+    fileNameSpan.textContent = 'No file chosen';
+    if (updateFileInput) updateFileInput.value = '';
+    if (updateFileNameSpan) updateFileNameSpan.textContent = 'No file chosen';
+  };
+
   if (clearBtn) {
     clearBtn.addEventListener('click', function() {
-      localStorage.removeItem('mutualList');
-      localStorage.removeItem('followingOnlyList');
-      localStorage.removeItem('followersOnlyList');
-      localStorage.removeItem('hasResults');
-      localStorage.removeItem('dataRuns');
-      resultsDiv.innerHTML = '';
-      resultsDiv.style.display = 'none';
-      clearBtn.style.display = 'none';
-      uploadForm.style.display = 'flex';
-      if (updateForm) updateForm.style.display = 'none';
-      fileInput.value = '';
-      fileNameSpan.textContent = 'No file chosen';
-      if (updateFileInput) updateFileInput.value = '';
-      if (updateFileNameSpan) updateFileNameSpan.textContent = 'No file chosen';
+      if (confirmOverlay) {
+        confirmOverlay.style.display = 'flex';
+        if (ackCheckbox) ackCheckbox.checked = false;
+        if (confirmClearBtn) confirmClearBtn.style.display = 'none';
+      } else {
+        clearData();
+      }
+    });
+  }
+
+  if (ackCheckbox) {
+    ackCheckbox.addEventListener('change', function() {
+      if (confirmClearBtn) {
+        confirmClearBtn.style.display = this.checked ? 'inline-block' : 'none';
+      }
+    });
+  }
+
+  if (confirmClearBtn) {
+    confirmClearBtn.addEventListener('click', function() {
+      clearData();
+      if (confirmOverlay) confirmOverlay.style.display = 'none';
     });
   }
 });

--- a/styles.css
+++ b/styles.css
@@ -295,6 +295,39 @@ footer p {
     color: white;
 }
 
+/* Modal overlay for clear confirmation */
+.modal-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.6);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
+}
+
+.modal {
+    background-color: #333;
+    padding: 20px;
+    border-radius: 8px;
+    text-align: center;
+}
+
+.warning-text {
+    color: #ff4c4c;
+    margin-bottom: 10px;
+}
+
+.ack-label {
+    color: #ff4c4c;
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
 
 @media (max-width: 1024px) {
     .footer-content {


### PR DESCRIPTION
## Summary
- add markup for a confirmation overlay in `index.html`
- style modal overlay and warning text
- control confirmation logic in `script.js` before clearing LocalStorage

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684661589e28832089e281779bf18272