### PR TITLE
Use ZIP metadata for run timestamps

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This tool compares the follower and following lists from your Instagram data.
 1. Upload your first Instagram ZIP using the form on the main page. The ZIP
    filename should look like `instagram-<username>-YYYY-MM-DD-*.zip`.
 2. After the results are displayed, a simple **Add Run** form appears below them. Use this to upload additional ZIP files whenever you have a new snapshot.
-3. Each upload is stored as a run with the extracted date. New entries that
-   didn't exist in the previous run are marked with a **NEW** badge in the
-   results pages.
+3. Each upload is stored as a run using the creation date embedded in the ZIP
+   metadata (not the filename). New entries that didn't exist in the previous
+   run are marked with a **NEW** badge in the results pages.
 4. Click **Clear Data** to remove all stored runs and reset both upload forms.
 

--- a/script.js
+++ b/script.js
@@ -158,6 +158,7 @@ document.addEventListener('DOMContentLoaded', function() {
             alert('The ZIP file is missing one or both required JSON files (following.json, followers_1.json).');
             return;
           }
+          const archiveDate = followingFile.date || followersFile.date || null;
           Promise.all([followingFile.async("string"), followersFile.async("string")]).then(function([followingContent, followersContent]) {
             const followingData = extractFollowingData(followingContent);
             const followersData = extractFollowersData(followersContent);
@@ -189,7 +190,7 @@ document.addEventListener('DOMContentLoaded', function() {
               }
             });
 
-            callback({ mutual, followingOnly, followersOnly });
+            callback({ mutual, followingOnly, followersOnly, timestamp: archiveDate });
           }).catch(function(error) {
             console.error('Error processing JSON files:', error);
           });
@@ -202,8 +203,9 @@ document.addEventListener('DOMContentLoaded', function() {
   };
 
   const saveRunAndShow = (file, data, isUpdate) => {
+    const runTimestamp = data.timestamp ? data.timestamp.toISOString() : extractDate(file.name);
     const run = {
-      timestamp: extractDate(file.name),
+      timestamp: runTimestamp,
       mutual: data.mutual,
       followingOnly: data.followingOnly,
       followersOnly: data.followersOnly


### PR DESCRIPTION
## Summary
- capture the creation date from the JSON files in the uploaded ZIP
- store that timestamp for each run instead of deriving it from the filename
- clarify README about using ZIP metadata for timestamps

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846655a85b48320b18cea504895c91a