### PR TITLE
Sort runs on load and update references

### DIFF
--- a/pages/followers.html
+++ b/pages/followers.html
@@ -24,8 +24,9 @@
   </footer>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      const runs = JSON.parse(localStorage.getItem('dataRuns') || '[]');
-      const latest = runs.length > 0 ? runs[runs.length - 1] : { followersOnly: [], timestamp: null };
+      const runs = JSON.parse(localStorage.getItem('dataRuns') || '[]')
+        .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      const latest = runs.length > 0 ? runs[0] : { followersOnly: [], timestamp: null };
       const followersOnlyList = latest.followersOnly || [];
       const listContainer = document.getElementById('list-container');
       const titleElem = document.getElementById('page-title');

--- a/pages/following.html
+++ b/pages/following.html
@@ -24,8 +24,9 @@
   </footer>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      const runs = JSON.parse(localStorage.getItem('dataRuns') || '[]');
-      const latest = runs.length > 0 ? runs[runs.length - 1] : { followingOnly: [], timestamp: null };
+      const runs = JSON.parse(localStorage.getItem('dataRuns') || '[]')
+        .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      const latest = runs.length > 0 ? runs[0] : { followingOnly: [], timestamp: null };
       const followingOnlyList = latest.followingOnly || [];
       const listContainer = document.getElementById('list-container');
       const titleElem = document.getElementById('page-title');

--- a/pages/mutual.html
+++ b/pages/mutual.html
@@ -24,8 +24,9 @@
   </footer>
   <script>
     document.addEventListener('DOMContentLoaded', function() {
-      const runs = JSON.parse(localStorage.getItem("dataRuns") || "[]");
-      const latest = runs.length > 0 ? runs[runs.length - 1] : { mutual: [], timestamp: null };
+      const runs = JSON.parse(localStorage.getItem("dataRuns") || "[]")
+        .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+      const latest = runs.length > 0 ? runs[0] : { mutual: [], timestamp: null };
       const mutualList = latest.mutual || [];
       const listContainer = document.getElementById("list-container");
       const titleElem = document.getElementById("page-title");

--- a/script.js
+++ b/script.js
@@ -82,9 +82,13 @@ document.addEventListener('DOMContentLoaded', function() {
   }
 
   let dataRuns = JSON.parse(localStorage.getItem('dataRuns') || '[]');
+  const sortDataRuns = () => {
+    dataRuns.sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
+  };
+  sortDataRuns();
   populateRunDates();
   if (dataRuns.length > 0) {
-    const latest = dataRuns[dataRuns.length - 1];
+    const latest = dataRuns[0];
     uploadForm.style.display = 'none';
     if (updateForm) updateForm.style.display = 'flex';
     showResults(latest.mutual, latest.followingOnly, latest.followersOnly);
@@ -212,7 +216,8 @@ document.addEventListener('DOMContentLoaded', function() {
     };
 
     if (isUpdate && dataRuns.length > 0) {
-      const prev = dataRuns[dataRuns.length - 1];
+      sortDataRuns();
+      const prev = dataRuns[0];
       const prevFollowSet = new Set(prev.followingOnly.map(i => i.username));
       const prevFanSet = new Set(prev.followersOnly.map(i => i.username));
       const prevMutualSet = new Set(prev.mutual.map(i => i.username));
@@ -229,7 +234,7 @@ document.addEventListener('DOMContentLoaded', function() {
     } else {
       dataRuns = [run];
     }
-
+    sortDataRuns();
     localStorage.setItem('dataRuns', JSON.stringify(dataRuns));
     // legacy keys for other pages
     localStorage.setItem('mutualList', JSON.stringify(run.mutual));
@@ -275,6 +280,8 @@ document.addEventListener('DOMContentLoaded', function() {
     localStorage.removeItem('followersOnlyList');
     localStorage.removeItem('hasResults');
     localStorage.removeItem('dataRuns');
+    dataRuns = [];
+    sortDataRuns();
     resultsDiv.innerHTML = '';
     resultsDiv.style.display = 'none';
     clearBtn.style.display = 'none';


### PR DESCRIPTION
## Summary
- sort stored runs by timestamp when loading and saving
- use the first item as the latest run after sorting
- propagate these changes to result pages

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68470abb21a08320a4e24ab04240676c