### PR TITLE
Add ability to delete stored runs

### DIFF
--- a/script.js
+++ b/script.js
@@ -55,9 +55,68 @@ document.addEventListener('DOMContentLoaded', function() {
   const populateRunDates = () => {
     if (!runDatesList) return;
     runDatesList.innerHTML = '';
-    dataRuns.forEach(run => {
+    dataRuns.forEach((run, index) => {
       const li = document.createElement('li');
-      li.textContent = run.timestamp;
+      const dateSpan = document.createElement('span');
+      dateSpan.textContent = run.timestamp;
+      li.appendChild(dateSpan);
+
+      const del = document.createElement('span');
+      del.textContent = '\u00D7';
+      del.className = 'delete-run';
+      li.appendChild(document.createTextNode(' '));
+      li.appendChild(del);
+
+      let tooltip;
+      const showTooltip = () => {
+        if (!tooltip) {
+          tooltip = document.createElement('div');
+          tooltip.className = 'run-tooltip';
+          tooltip.textContent = 'Delete this run';
+          document.body.appendChild(tooltip);
+        }
+        const rect = del.getBoundingClientRect();
+        tooltip.style.top = (window.scrollY + rect.bottom + 5) + 'px';
+        tooltip.style.left = (window.scrollX + rect.left) + 'px';
+      };
+      const hideTooltip = () => {
+        del._hideTimeout = setTimeout(() => {
+          const iconHovered = del.matches(':hover');
+          const tooltipHovered = tooltip ? tooltip.matches(':hover') : false;
+          if (!iconHovered && !tooltipHovered && tooltip) {
+            document.body.removeChild(tooltip);
+            tooltip = null;
+          }
+        }, 200);
+      };
+
+      del.addEventListener('mouseenter', (e) => {
+        if (del._hideTimeout) clearTimeout(del._hideTimeout);
+        showTooltip();
+      });
+      del.addEventListener('mouseleave', hideTooltip);
+
+      del.addEventListener('click', () => {
+        dataRuns.splice(index, 1);
+        if (dataRuns.length === 0) {
+          clearData();
+          dataRuns = [];
+          populateRunDates();
+          return;
+        }
+        localStorage.setItem('dataRuns', JSON.stringify(dataRuns));
+        const latest = dataRuns[dataRuns.length - 1];
+        localStorage.setItem('mutualList', JSON.stringify(latest.mutual));
+        localStorage.setItem('followingOnlyList', JSON.stringify(latest.followingOnly));
+        localStorage.setItem('followersOnlyList', JSON.stringify(latest.followersOnly));
+        localStorage.setItem('hasResults', 'true');
+
+        showResults(latest.mutual, latest.followingOnly, latest.followersOnly);
+        if (clearBtn) clearBtn.style.display = 'inline-block';
+        if (updateForm) updateForm.style.display = 'flex';
+        populateRunDates();
+      });
+
       runDatesList.appendChild(li);
     });
   };

--- a/styles.css
+++ b/styles.css
@@ -389,3 +389,21 @@ footer p {
         width: 100%;
     }
 }
+
+.delete-run {
+    margin-left: 5px;
+    color: #ff4c4c;
+    cursor: pointer;
+    font-weight: bold;
+}
+
+.run-tooltip {
+    position: absolute;
+    background-color: #fff;
+    color: #000;
+    border-radius: 8px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    padding: 5px 10px;
+    font-size: 0.8em;
+    z-index: 1000;
+}


### PR DESCRIPTION
## Summary
- enable deleting previous runs from the side panel
- update localStorage when a run is removed
- show tooltips for delete buttons
- style delete buttons and tooltips

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68470ab09f088320aa7ed2ba84d04ac3