### PR TITLE
Format date display for runs

### DIFF
--- a/pages/followers.html
+++ b/pages/followers.html
@@ -28,13 +28,19 @@
         .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
       const latest = runs.length > 0 ? runs[0] : { followersOnly: [], timestamp: null };
       const followersOnlyList = latest.followersOnly || [];
+      const formatDate = (ts) => {
+        const d = new Date(ts);
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${month}/${day}/${d.getFullYear()}`;
+      };
       const listContainer = document.getElementById('list-container');
       const titleElem = document.getElementById('page-title');
 
       titleElem.textContent = `Followers Only (${followersOnlyList.length})`;
       if (latest.timestamp) {
         const ts = document.createElement('p');
-        ts.textContent = `Snapshot: ${latest.timestamp}`;
+        ts.textContent = `Snapshot: ${formatDate(latest.timestamp)}`;
         titleElem.insertAdjacentElement('afterend', ts);
       }
 

--- a/pages/following.html
+++ b/pages/following.html
@@ -28,13 +28,19 @@
         .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
       const latest = runs.length > 0 ? runs[0] : { followingOnly: [], timestamp: null };
       const followingOnlyList = latest.followingOnly || [];
+      const formatDate = (ts) => {
+        const d = new Date(ts);
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${month}/${day}/${d.getFullYear()}`;
+      };
       const listContainer = document.getElementById('list-container');
       const titleElem = document.getElementById('page-title');
 
       titleElem.textContent = `Following Only (${followingOnlyList.length})`;
       if (latest.timestamp) {
         const ts = document.createElement('p');
-        ts.textContent = `Snapshot: ${latest.timestamp}`;
+        ts.textContent = `Snapshot: ${formatDate(latest.timestamp)}`;
         titleElem.insertAdjacentElement('afterend', ts);
       }
 

--- a/pages/mutual.html
+++ b/pages/mutual.html
@@ -28,13 +28,19 @@
         .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp));
       const latest = runs.length > 0 ? runs[0] : { mutual: [], timestamp: null };
       const mutualList = latest.mutual || [];
+      const formatDate = (ts) => {
+        const d = new Date(ts);
+        const month = String(d.getMonth() + 1).padStart(2, '0');
+        const day = String(d.getDate()).padStart(2, '0');
+        return `${month}/${day}/${d.getFullYear()}`;
+      };
       const listContainer = document.getElementById("list-container");
       const titleElem = document.getElementById("page-title");
 
       titleElem.textContent = `Mutual Connections (${mutualList.length})`;
       if (latest.timestamp) {
         const ts = document.createElement("p");
-        ts.textContent = `Snapshot: ${latest.timestamp}`;
+        ts.textContent = `Snapshot: ${formatDate(latest.timestamp)}`;
         titleElem.insertAdjacentElement("afterend", ts);
       }
 

--- a/script.js
+++ b/script.js
@@ -61,12 +61,13 @@ document.addEventListener('DOMContentLoaded', function() {
 
   const populateRunDates = () => {
     if (!runDatesList) return;
+    sortDataRuns();
     runDatesList.innerHTML = '';
 
     dataRuns.forEach((run, index) => {
       const li = document.createElement('li');
       const dateSpan = document.createElement('span');
-      dateSpan.textContent = run.timestamp;
+      dateSpan.textContent = formatDate(run.timestamp);
       li.appendChild(dateSpan);
 
       const del = document.createElement('span');


### PR DESCRIPTION
## Summary
- show run dates in MM/DD/YYYY format
- display latest runs first in the sidebar
- show formatted snapshot date on results pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68470ddb89ec8320a6656f54230718fd